### PR TITLE
publish junit test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint and Test Charts
+name: CI
 on:
   pull_request:
     branches:
@@ -66,6 +66,7 @@ jobs:
     steps:
       # Testing longhart chart in the rancher/s390x/charts repo by setting workdir before helm upgrade
       - name: Run Tests for Longhorn Chart
+        id: lh
         run: |
           export last_created_dir=$(ls -td charts/longhorn/* | head -1)
           sed -i '/^helm upgrade --install=true longhorn.*/i git clone -n https://github.com/rancher/s390x-charts.git && cd s390x-charts.git && git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin '"${GITHUB_REF}"' && git checkout -qf FETCH_HEAD && cd '"${last_created_dir}"'' openstack_env/scripts/tests_s390x/longhorn.sh
@@ -73,7 +74,20 @@ jobs:
           cp  ~/developer-s390-openrc.sh env.conf
           chmod 400 data/id_shared
           sed -i 's/\-it//g' varke 
-          ./varke run -n 1:0 -t longhorn -e SUFFIX=s390x-charts-lh -e INTEGRATION=1 -k
+          ./varke run -n 1:2 -t longhorn -e SUFFIX=s390x-charts-lh -e INTEGRATION=1 -k
+          echo ::set-output name=cluster::"$(ls | grep 'cluster')"
+
+      - name: Upload # upload event file
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2  # upload test results
+        with:
+          name: test-results
+          path: "openstack_env/scripts/${{ steps.lh.outputs.cluster }}/logs/longhorn-test-junit-report.xml"
 
   destroy-vm:
     needs: [run-tests]

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,40 @@
+name: Unit Test Results
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
+      - dev-v*
+      - release-v*
+      - test-upstream-charts
+
+jobs:
+  unit-test-results:
+    name: Junit test results
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
adding a second workflow called **test-report.yml** for publishing [junit test results when PRs are done by forked repositories](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches). 
This workflow will be automatically run whenever the CI workflow is completed.
